### PR TITLE
Add global run function

### DIFF
--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -99,6 +99,9 @@ declare function suiteTeardown(action: () => void): void;
 
 declare function suiteTeardown(action: (done: MochaDone) => void): void;
 
+// Used with the --delay flag; see https://mochajs.org/#hooks
+declare function run(): void;
+
 declare class Mocha {
     constructor(options?: {
         grep?: RegExp;


### PR DESCRIPTION
From https://mochajs.org/#hooks:
> If you need to perform asynchronous operations before any of your suites are run, you may delay the root suite. Simply run Mocha with the --delay flag. This will provide a special function, run(), in the global context.